### PR TITLE
Mark a scale up as a cold start. 

### DIFF
--- a/src/Orchestrator/CloudRepublic.BenchMark.Orchestrator/Services/BenchMarkTypeService.cs
+++ b/src/Orchestrator/CloudRepublic.BenchMark.Orchestrator/Services/BenchMarkTypeService.cs
@@ -38,27 +38,21 @@ public class BenchMarkTypeService : IBenchMarkTypeService
 
             for (var i = 0; i < coldCalls; i++)
             {
-                tasksCold.Add(_benchMarkService.RunBenchMarkAsync(benchMarkType));
+                tasksCold.Add(_benchMarkService.RunBenchMarkAsync(benchMarkType, i));
             }
 
-            await Task.WhenAll(tasksCold);
+            var coldResponses = await Task.WhenAll(tasksCold);
 
             await Task.Delay(TimeSpan.FromSeconds(delayBetweenCalls));
 
             for (var i = 0; i < warmCalls; i++)
             {
-                tasksWarm.Add(_benchMarkService.RunBenchMarkAsync(benchMarkType));
+                tasksWarm.Add(_benchMarkService.RunBenchMarkAsync(benchMarkType, i + coldCalls));
             }
 
-            await Task.WhenAll(tasksWarm);
+            var warmResponses = await Task.WhenAll(tasksWarm);
 
-            results.AddRange(ResultConverter.ConvertToResultObject(tasksCold.Select(t => t.Result), benchMarkType, true));
-            results.AddRange(ResultConverter.ConvertToResultObject(tasksWarm.Select(t => t.Result), benchMarkType, false));
-
-            for(var i = 0; i < results.Count; i++)
-            {
-                results[i].CallPositionNumber = i;
-            }
+            results.AddRange(ResultConverter.ConvertToResultObject(coldResponses, warmResponses, benchMarkType));
         }
         return results;
     }

--- a/src/Orchestrator/CloudRepublic.BenchMark.Orchestrator/Statics/ResultConverter.cs
+++ b/src/Orchestrator/CloudRepublic.BenchMark.Orchestrator/Statics/ResultConverter.cs
@@ -9,10 +9,11 @@ namespace CloudRepublic.BenchMark.Orchestrator.Statics;
 public static class ResultConverter
 {
     public static List<BenchMarkResult> ConvertToResultObject(
-        IEnumerable<BenchMarkResponse> benchMarkResponses,
-        BenchMarkType benchMarkType, bool isColdRequest)
+        IEnumerable<BenchMarkResponse> coldBenchMarkResponses,
+        IEnumerable<BenchMarkResponse> warmBenchMarkResponses,
+        BenchMarkType benchMarkType)
     {
-        return benchMarkResponses.Select(benchMarkResponse => new BenchMarkResult
+        var coldResults = coldBenchMarkResponses.Select(benchMarkResponse => new BenchMarkResult
         {
             Id = Guid.NewGuid().ToString(),
             CloudProvider = benchMarkType.CloudProvider,
@@ -23,8 +24,35 @@ public static class ResultConverter
             Success = benchMarkResponse.Success,
             StatusCode = benchMarkResponse.StatusCode,
             RequestDuration = Convert.ToInt32(benchMarkResponse.Duration),
-            IsColdRequest = isColdRequest,
+            IsColdRequest = true,
+            IsScaleUp = false,
+            ServerName = benchMarkResponse.ServerName,
             CreatedAt = DateTimeOffset.UtcNow,
+            CallPositionNumber = benchMarkResponse.CallPositionNumber
         }).ToList();
+        
+        var warmResults = warmBenchMarkResponses.Select(benchMarkResponse =>
+        {
+            var newServer = coldResults.FirstOrDefault(x => x.ServerName == benchMarkResponse.ServerName) is null;
+            return new BenchMarkResult
+            {
+                Id = Guid.NewGuid().ToString(),
+                CloudProvider = benchMarkType.CloudProvider,
+                HostingEnvironment = benchMarkType.HostEnvironment,
+                Runtime = benchMarkType.Runtime,
+                Language = benchMarkType.Language,
+                Sku = benchMarkType.Sku,
+                Success = benchMarkResponse.Success,
+                StatusCode = benchMarkResponse.StatusCode,
+                RequestDuration = Convert.ToInt32(benchMarkResponse.Duration),
+                IsColdRequest = newServer,
+                IsScaleUp = newServer,
+                ServerName = benchMarkResponse.ServerName,
+                CreatedAt = DateTimeOffset.UtcNow,
+                CallPositionNumber = benchMarkResponse.CallPositionNumber
+            };
+        }).ToList();
+
+        return coldResults.Concat(warmResults).OrderBy(r => r.CallPositionNumber).ToList();
     }
 }

--- a/src/Shared/CloudRepublic.BenchMark.Application/Interfaces/IBenchMarkService.cs
+++ b/src/Shared/CloudRepublic.BenchMark.Application/Interfaces/IBenchMarkService.cs
@@ -10,6 +10,6 @@ namespace CloudRepublic.BenchMark.Application.Interfaces
         /// </summary>
         /// <param name="clientName"></param>
         /// <returns></returns>
-        Task<BenchMarkResponse> RunBenchMarkAsync(BenchMarkType benchMarkType);
+        Task<BenchMarkResponse> RunBenchMarkAsync(BenchMarkType benchMarkType, int CallPositionNumber);
     }
 }

--- a/src/Shared/CloudRepublic.BenchMark.Application/Models/BenchMarkResponse.cs
+++ b/src/Shared/CloudRepublic.BenchMark.Application/Models/BenchMarkResponse.cs
@@ -1,4 +1,4 @@
 namespace CloudRepublic.BenchMark.Application.Models
 {
-    public record BenchMarkResponse(bool Success, int StatusCode, long Duration);
+    public record BenchMarkResponse(bool Success, int StatusCode, long Duration, string ServerName, int CallPositionNumber);
 }

--- a/src/Shared/CloudRepublic.BenchMark.Application/Services/BenchMarkService.cs
+++ b/src/Shared/CloudRepublic.BenchMark.Application/Services/BenchMarkService.cs
@@ -28,11 +28,11 @@ namespace CloudRepublic.BenchMark.Application.Services
                 var response = await client.SendAsync(requestMessage);
                 var result = stopWatch.ElapsedMilliseconds;
                 
-                return new BenchMarkResponse(response.IsSuccessStatusCode, (int)response.StatusCode, result);
+                return new BenchMarkResponse(response.IsSuccessStatusCode, (int)response.StatusCode, result, await response.Content.ReadAsStringAsync());
             }
             catch (Exception)
             {
-                return new BenchMarkResponse(false, 0, 0);
+                return new BenchMarkResponse(false, 0, 0, null);
             }
         }
     }

--- a/src/Shared/CloudRepublic.BenchMark.Application/Services/BenchMarkService.cs
+++ b/src/Shared/CloudRepublic.BenchMark.Application/Services/BenchMarkService.cs
@@ -15,7 +15,7 @@ namespace CloudRepublic.BenchMark.Application.Services
         {
             _httpClientFactory = httpClientFactory;
         }
-        public async Task<BenchMarkResponse> RunBenchMarkAsync(BenchMarkType benchMarkType)
+        public async Task<BenchMarkResponse> RunBenchMarkAsync(BenchMarkType benchMarkType, int CallPositionNumber)
         {
             var client = _httpClientFactory.CreateClient("benchmarkTester");
             try
@@ -28,11 +28,11 @@ namespace CloudRepublic.BenchMark.Application.Services
                 var response = await client.SendAsync(requestMessage);
                 var result = stopWatch.ElapsedMilliseconds;
                 
-                return new BenchMarkResponse(response.IsSuccessStatusCode, (int)response.StatusCode, result, await response.Content.ReadAsStringAsync());
+                return new BenchMarkResponse(response.IsSuccessStatusCode, (int)response.StatusCode, result, await response.Content.ReadAsStringAsync(), CallPositionNumber);
             }
             catch (Exception)
             {
-                return new BenchMarkResponse(false, 0, 0, null);
+                return new BenchMarkResponse(false, 0, 0, null, CallPositionNumber);
             }
         }
     }

--- a/src/Shared/CloudRepublic.BenchMark.Domain/Entities/BenchMarkResult.cs
+++ b/src/Shared/CloudRepublic.BenchMark.Domain/Entities/BenchMarkResult.cs
@@ -20,5 +20,7 @@ public record BenchMarkResult
     public int CallPositionNumber { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
         
+    public string ServerName { get; set; }
     public bool IsColdRequest { get; set; }
+    public bool IsScaleUp { get; set; }
 }


### PR DESCRIPTION
Mark scale ups as a cold start and make it traceable why it is a cold start.
This should fix some odd behaviour with linux functions. We should extend the frontend in the future to show the number of instances per run to more accurately reflect the amount of cold starts you will experience per function type.